### PR TITLE
Resolved broken door automations

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -129,8 +129,8 @@
   trigger:
   - type: opened
     platform: device
-    device_id: 2687f04f008c11eb9e18b192b354e7d1
-    entity_id: binary_sensor.openclose_2
+    device_id: 2b286a18941c258ce855c86cfc4788e9
+    entity_id: binary_sensor.frontdoor
     domain: binary_sensor
     for:
       hours: 0
@@ -180,13 +180,9 @@
   trigger:
   - type: not_opened
     platform: device
-    device_id: 2687f04f008c11eb9e18b192b354e7d1
-    entity_id: binary_sensor.openclose_2
+    device_id: 2b286a18941c258ce855c86cfc4788e9
+    entity_id: binary_sensor.frontdoor
     domain: binary_sensor
-    for:
-      hours: 0
-      minutes: 0
-      seconds: 5
   condition: []
   action:
   - service: notify.telegram


### PR DESCRIPTION
# Release Notes

`Alert Front Door` and `Confirmation Door Closed` automation notifications were broken due to having to reinstall deCONZ.