### PR TITLE
Updated gitignore + Google Home HACS integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ _pycache_
 aircast.xml
 deps/
 home-assistant.log.1
+home-assistant.log.fault
 home-assistant_v2.db-shm 
 home-assistant_v2.db-wal
 tts/

--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -36,7 +36,8 @@ BINARY_SENSOR_DEVICE_CLASS: Final = "connectivity"
 # Platforms
 SENSOR: Final = "sensor"
 SWITCH: Final = "switch"
-PLATFORMS: Final = [SENSOR, SWITCH]
+NUMBER: Final = "number"
+PLATFORMS: Final = [SENSOR, SWITCH, NUMBER]
 
 # Services
 SERVICE_REBOOT: Final = "reboot_device"

--- a/custom_components/google_home/manifest.json
+++ b/custom_components/google_home/manifest.json
@@ -19,7 +19,7 @@
   "requirements": [
     "glocaltokens==0.5.1"
   ],
-  "version": "1.8.1",
+  "version": "1.8.2",
   "zeroconf": [
     "_googlecast._tcp.local."
   ],


### PR DESCRIPTION
* Updated to v1.8.2 of Google Home integration.
* Added home-assistant.log.fault to ignore list. 