### PR TITLE
fix(truenas): correct network divisor 10024 -> 1024 (#833)

### DIFF
--- a/includes/templates/sensor/truenas.yaml
+++ b/includes/templates/sensor/truenas.yaml
@@ -16,9 +16,9 @@
     - name: "TrueNAS Upload"
       unique_id: 38e48d20-f53b-496c-87a5-dd413f11ba70
       unit_of_measurement: "MiB"
-      state: "{{ (states('sensor.truenas_enp4s0_tx') | float / 10024) | round(2) }}"
+      state: "{{ (states('sensor.truenas_enp4s0_tx') | float / 1024) | round(2) }}"
     # TrueNAS Download
     - name: "TrueNAS Download"
       unique_id: b3f26047-93e1-44a9-8d9a-3e3f786da98d
       unit_of_measurement: "MiB"
-      state: "{{ (states('sensor.truenas_enp4s0_rx') | float / 10024) | round(2) }}"
+      state: "{{ (states('sensor.truenas_enp4s0_rx') | float / 1024) | round(2) }}"


### PR DESCRIPTION
## Summary

The TrueNAS *Upload* / *Download* template sensors divide the raw interface `tx`/`rx` bytes by `10024` instead of `1024`, so the `MiB` reading comes out about 10× too small.

Swap both literals to `1024` so 1 MiB renders as 1024 bytes as intended.

Fixes #833

## Test plan

- [x] \`python3 -c 'import yaml; yaml.safe_load(open(\"includes/templates/sensor/truenas.yaml\"))'\` — YAML parses cleanly
- [x] Diff limited to the two \`/ 10024\` -> \`/ 1024\` changes; no other sensor affected