### PR TITLE
(#970) Added 'Assistant Controls' to System view

### DIFF
--- a/includes/lovelace/views/1_primary.yaml
+++ b/includes/lovelace/views/1_primary.yaml
@@ -201,7 +201,7 @@ cards:
                     ]]]
                   name: |
                     [[[
-                      return "Feels like " + states['sensor.climacell_feels_like'].state + '°F'
+                      return states['sensor.jacket_recommendation'].state
                     ]]]
                   template:
                     - weather_layout
@@ -223,7 +223,6 @@ cards:
                     - icon_state: mdi:door-open
                     - icon_default: custom:room-hallway
                 #----------------------------------------------------------------
-                ## Office button
                 #----------------------------------------------------------------
                 - type: "custom:decluttering-card"
                   template: declutter_temp_button
@@ -513,6 +512,9 @@ cards:
                   entity: media_player.shield_tv
                   tap_action:
                     action: toggle
+                  double_tap_action:
+                    action: more-info
+                    entity: media_player.shield
                   template:
                     - icon_tv
                   # TODO: #263 Create TV controls pop-up

--- a/includes/lovelace/views/3_system.yaml
+++ b/includes/lovelace/views/3_system.yaml
@@ -778,8 +778,9 @@ cards:
                       card_mod: *section_card_mod
                     - entity: sensor.m5stack_living_room_assistant
                       name: "Living Room"
+                      icon: "mdi:record"
                       tap_action:
-                        actions: call-service
+                        action: call-service
                         service: switch.toggle
                         target:
                           entity_id: switch.m5stack_living_room_wake_toggle
@@ -787,7 +788,7 @@ cards:
                       name: "Office"
                       icon: "mdi:record"
                       tap_action:
-                        actions: call-service
+                        action: call-service
                         service: switch.toggle
                         target:
                           entity_id: switch.m5stack_office_wake_toggle
@@ -795,7 +796,7 @@ cards:
                       name: "Loft"
                       icon: "mdi:record"
                       tap_action:
-                        actions: call-service
+                        action: call-service
                         service: switch.toggle
                         target:
                           entity_id: switch.m5stack_loft_wake_toggle

--- a/includes/lovelace/views/3_system.yaml
+++ b/includes/lovelace/views/3_system.yaml
@@ -701,50 +701,6 @@ cards:
                   card_mod: *entities_card_mod
                   entities:
                     #----------------------------------------------------------------
-                    ## PC CPU Utilization Graph
-                    #----------------------------------------------------------------
-                    - type: custom:hui-horizontal-stack-card
-                      cards:
-                        - type: "custom:decluttering-card"
-                          template: declutter_system_graph
-                          variables:
-                            - sensor: sensor.pc_cpu_load
-                            - name: CPU
-                            - server: Zoidberg
-                            - title: CPU Utilization
-                            - green: 25
-                            - yellow: 50
-                            - orange: 75
-                            - red: 100
-                        #----------------------------------------------------------------
-                        ## PC GPU Load Graph
-                        #----------------------------------------------------------------
-                        - type: "custom:decluttering-card"
-                          template: declutter_system_graph
-                          variables:
-                            - sensor: sensor.pc_gpu_load
-                            - name: GPU
-                            - server: Zoidberg
-                            - title: GPU Utilization
-                            - green: 25
-                            - yellow: 50
-                            - orange: 75
-                            - red: 100
-                        #----------------------------------------------------------------
-                        ## PC GPU Temp Graph
-                        #----------------------------------------------------------------
-                        - type: "custom:decluttering-card"
-                          template: declutter_system_graph
-                          variables:
-                            - sensor: sensor.pc_gpu_temp
-                            - name: GPU ºF
-                            - server: Zoidberg
-                            - title: GPU Temperature
-                            - green: 140
-                            - yellow: 158
-                            - orange: 176
-                            - red: 210
-                    #----------------------------------------------------------------
                     ## PC Boot Button
                     #----------------------------------------------------------------
                     # TODO: #312 Format Dekstop + HA system control buttons.

--- a/includes/lovelace/views/3_system.yaml
+++ b/includes/lovelace/views/3_system.yaml
@@ -731,7 +731,7 @@ cards:
                             haptic: light
                           template: icon_name
           #################################################################
-          ## Claude Controls
+          ## Assistant Controls
           #################################################################
           Claude:
             type: "custom:mod-card"
@@ -742,9 +742,12 @@ cards:
               square: false
               cards:
                 - type: entities
-                  title: Claude Usage
+                  title: Assistant Controls
                   card_mod: *entities_card_mod
                   entities:
+                    - type: section
+                      label: Claude Usage
+                      card_mod: *section_card_mod
                     - entity: sensor.claude_session_reset_time
                       name: Session Reset
                     - entity: sensor.claude_weekly_reset_day
@@ -770,3 +773,62 @@ cards:
                           name: Session Usage
                         - entity: sensor.claude_week_usage
                           name: Week Usage
+                    - type: section
+                      label: Voice Assistants
+                      card_mod: *section_card_mod
+                    - entity: sensor.m5stack_living_room_assistant
+                      name: "Living Room"
+                      tap_action:
+                        actions: call-service
+                        service: switch.toggle
+                        target:
+                          entity_id: switch.m5stack_living_room_wake_toggle
+                    - entity: sensor.m5stack_office_assistant
+                      name: "Office"
+                      icon: "mdi:record"
+                      tap_action:
+                        actions: call-service
+                        service: switch.toggle
+                        target:
+                          entity_id: switch.m5stack_office_wake_toggle
+                    - entity: sensor.m5stack_loft_assistant
+                      name: "Loft"
+                      icon: "mdi:record"
+                      tap_action:
+                        actions: call-service
+                        service: switch.toggle
+                        target:
+                          entity_id: switch.m5stack_loft_wake_toggle
+                    - type: section
+                      label: Ollama
+                      card_mod: *section_card_mod
+                    - type: custom:hui-horizontal-stack-card
+                      cards:
+                        #----------------------------------------------------------------
+                        ## Leela CPU Utilization Graph
+                        #----------------------------------------------------------------
+                        - type: "custom:decluttering-card"
+                          template: declutter_system_graph
+                          variables:
+                            - sensor: sensor.ollama_cpu_usage_total
+                            - name: CPU
+                            - server: Ollama
+                            - title: CPU Utilization
+                            - green: 25
+                            - yellow: 50
+                            - orange: 75
+                            - red: 100
+                        #----------------------------------------------------------------
+                        ## Leela CPU Utilization Graph
+                        #----------------------------------------------------------------
+                        - type: "custom:decluttering-card"
+                          template: declutter_system_graph
+                          variables:
+                            - sensor: sensor.ollama_memory_usage_percentage
+                            - name: RAM
+                            - server: Ollama
+                            - title: RAM Utilization
+                            - green: 25
+                            - yellow: 50
+                            - orange: 75
+                            - red: 100

--- a/includes/lovelace/views/3_system.yaml
+++ b/includes/lovelace/views/3_system.yaml
@@ -784,6 +784,9 @@ cards:
                         service: switch.toggle
                         target:
                           entity_id: switch.m5stack_living_room_wake_toggle
+                      double_tap_action:
+                        action: navigate
+                        navigation_path: /config/devices/device/3bb3c33455c31c794a4c2971f59d8a38
                     - entity: sensor.m5stack_office_assistant
                       name: "Office"
                       icon: "mdi:record"
@@ -792,6 +795,9 @@ cards:
                         service: switch.toggle
                         target:
                           entity_id: switch.m5stack_office_wake_toggle
+                      double_tap_action:
+                        action: navigate
+                        navigation_path: /config/devices/device/98074542f9d0d3cee7d5be78e840ea0f
                     - entity: sensor.m5stack_loft_assistant
                       name: "Loft"
                       icon: "mdi:record"
@@ -800,6 +806,9 @@ cards:
                         service: switch.toggle
                         target:
                           entity_id: switch.m5stack_loft_wake_toggle
+                      double_tap_action:
+                        action: navigate
+                        navigation_path: /config/devices/device/b241806292966c0a697ccfc339b040ad
                     - type: section
                       label: Ollama
                       card_mod: *section_card_mod

--- a/integrations/recorder.yaml
+++ b/integrations/recorder.yaml
@@ -54,6 +54,9 @@ recorder:
       # Claude Usage\
       - sensor.claude_session_usage
       - sensor.claude_week_usage
+      # Ollama
+      - sensor.ollama_cpu_usage_total
+      - sensor.ollama_memory_usage_percentage
     entity_globs:
       - person.jeffrey_*
       - person.tiffany_*


### PR DESCRIPTION
* Worked on #973 
* Worked on #974 
* Added Ollama CPU + RAM sensors to Recorder.
* Added tap_action on Voice Assistant entity rows in System view.
* Added double_tap_action to navigate to device pages for Voice Assistant rows.
* Added 'jacket' sensor to Weather button.
* Added double_tap 'more-info' controls to TV button.
* Removed unused mini-graphs from Desktop tab of System view.